### PR TITLE
Minor style updates to the new Add Component toolbox modal

### DIFF
--- a/src/Internals/ToolboxModal.js
+++ b/src/Internals/ToolboxModal.js
@@ -144,7 +144,6 @@ const styles = (theme) => ({
     width: 900,
     maxWidth: "100%",
     height: "calc(85vh - 100px)",
-    // border: `1px solid ${theme.colors["gray100"]}`,
     borderRadius: theme.globalBorderRadius,
     backgroundColor: theme.colors["white"],
     boxShadow: theme.globalBoxShadow,

--- a/src/Internals/ToolboxModal.js
+++ b/src/Internals/ToolboxModal.js
@@ -6,8 +6,7 @@ import find from "lodash/find";
 import noScroll from "no-scroll";
 
 import Button from "elevate-ui/Button";
-import Cancel from "elevate-ui-icons/Cancel";
-import AddCircle from "elevate-ui-icons/AddCircle";
+import Add from "elevate-ui-icons/Add";
 
 import Sidebar from "./ToolboxModal/Sidebar";
 import ComponentPreview from "./ToolboxModal/ComponentPreview";
@@ -17,6 +16,7 @@ type $Props = {
   className?: string,
   id?: string,
   onSelect: Function,
+  theme: Object,
 };
 
 type $State = {
@@ -76,7 +76,7 @@ class ToolboxModal extends Component<$Props, $State> {
   };
 
   render() {
-    const { classes, className, onSelect } = this.props;
+    const { classes, className, onSelect, theme } = this.props;
     const {
       activeComponent,
       filteredComponents,
@@ -106,14 +106,13 @@ class ToolboxModal extends Component<$Props, $State> {
                 noScroll.off();
                 return onSelect(null, null);
               }}
-              icon={<Cancel />}
-              color="#EEEEEE"
+              color={theme.colors.gray200 || "#EEEEEE"}
               isOutlined
             >
               Cancel
             </Button>
             <Button
-              icon={<AddCircle />}
+              icon={<Add />}
               disabled={!activeComponent ? true : false}
               color="secondary"
               onClick={() => {
@@ -145,12 +144,12 @@ const styles = (theme) => ({
     width: 900,
     maxWidth: "100%",
     height: "calc(85vh - 100px)",
-    ...theme.globalPadding,
-    border: `1px solid ${theme.colors["gray100"]}`,
+    // border: `1px solid ${theme.colors["gray100"]}`,
     borderRadius: theme.globalBorderRadius,
     backgroundColor: theme.colors["white"],
     boxShadow: theme.globalBoxShadow,
     zIndex: 999,
+    overflow: "hidden",
   },
   mask: {
     display: "block",
@@ -182,9 +181,10 @@ const styles = (theme) => ({
     justifyContent: "flex-end",
     alignItems: "center",
     borderTop: `1px solid ${theme.colors["gray200"]}`,
-    paddingTop: "12px",
-    "& *+*": {
-      marginLeft: 20,
+    backgroundColor: theme.colors.gray050,
+    padding: "12px",
+    "& * + *": {
+      marginLeft: "12px",
     },
   },
 });

--- a/src/Internals/ToolboxModal/ComponentPreview.js
+++ b/src/Internals/ToolboxModal/ComponentPreview.js
@@ -38,22 +38,24 @@ const ComponentPreview = ({ activeComponent, classes }: $Props) => {
 
 const styles = (theme) => ({
   root: {
-    flex: "0 1 auto",
+    flex: "1 1 auto",
     position: "relative",
-    paddingLeft: 20,
     overflowY: "scroll",
+    padding: "20px",
   },
   previewImage: {
     maxWidth: "100%",
     height: "auto",
   },
   noSelection: {
+    flex: "1 1 auto",
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
     alignItems: "center",
+    textAlign: "center",
     minHeight: "100%",
-    paddingLeft: 20,
+    padding: "20px",
   },
 });
 

--- a/src/Internals/ToolboxModal/Sidebar.js
+++ b/src/Internals/ToolboxModal/Sidebar.js
@@ -27,16 +27,17 @@ const Sidebar = ({
     <Typography type="heading4" gutterBottom>
       Select a component:
     </Typography>
-    <div className={classes.inputWrapper}>
+    <label className={classes.inputWrapper}>
       <input
         className={classes.input}
         type="text"
         value={filterInput}
         onChange={filterComponents}
         placeholder="Filter components..."
+        autoFocus
       />
       <Search className={classes.inputIcon} size={32} />
-    </div>
+    </label>
     {components.map((component) => {
       return (
         <ToolboxItem
@@ -64,7 +65,7 @@ const styles = (theme) => ({
     flex: "0 0 375px",
     justifyContent: "flex-start",
     alignItems: "flex-start",
-    paddingRight: 20,
+    padding: "20px",
     overflowY: "scroll",
     overflowX: "visible",
     borderRight: `1px solid ${theme.colors["gray200"]}`,
@@ -94,7 +95,8 @@ const styles = (theme) => ({
     fontSize: "16px",
     lineHeight: "20px",
     backgroundColor: "#fff",
-    border: `1px solid ${theme.colors.gray300}`,
+    border: `1px solid ${theme.colors.gray200}`,
+    borderRadius: theme.globalBorderRadius,
     padding: "8px 46px 8px 12px",
     boxShadow: "none", // Reset default inputs for mozilla
     "-webkit-appearance": "none", // Reset default browser styles
@@ -111,6 +113,7 @@ const styles = (theme) => ({
   },
   inputIcon: {
     position: "absolute",
+    color: theme.colors.gray300,
     right: 10,
   },
 });

--- a/src/Internals/ToolboxModal/ToolboxItem.js
+++ b/src/Internals/ToolboxModal/ToolboxItem.js
@@ -27,12 +27,11 @@ export default withStyles((theme) => ({
     justifyContent: "flex-start",
     alignItems: "center",
     width: "100%",
-    minHeight: "64px",
     color: "black",
-    border: `1px solid #E0E0E0`,
+    border: `1px solid ${theme.colors.gray200}`,
     borderRadius: "4px",
     userSelect: "none",
-    padding: "8px 18px",
+    padding: "12px 16px",
 
     "&:hover": {
       backgroundColor: theme.colors["gray100"],


### PR DESCRIPTION
Before:
<img width="995" alt="screen shot 2018-11-07 at 4 07 51 pm" src="https://user-images.githubusercontent.com/5051745/48166901-4e8bca00-e2a7-11e8-836a-f8973c4ac75a.png">

After:
<img width="962" alt="screen shot 2018-11-07 at 4 01 04 pm" src="https://user-images.githubusercontent.com/5051745/48166734-b1309600-e2a6-11e8-9acb-739cc6e2c4ce.png">

- Adjusted padding around bottom bar/action buttons
- Added a gray050 background to bottom bar
- Removed the icon from the cancel button
- Centered the zero-content placeholder in the right panel
- Added autoFocus prop to the search input
- Updated search input border color to match toolbox items
- Updated search input magnifying glass to be more subtle, wrapped entire component in a `label` to ensure clicking the icon focuses the input
- Removed maxHeight from toolbox items, adjusted padding slightly