### PR TITLE
Component Labels

### DIFF
--- a/src/Components/Button/index.js
+++ b/src/Components/Button/index.js
@@ -23,6 +23,7 @@ export default {
   Render,
   Form,
   type: "Button",
+  label: "Button",
   description: "Button component that can be used as a call to action.",
 
   // validation: Yup.object()

--- a/src/Components/Email/Button/index.js
+++ b/src/Components/Email/Button/index.js
@@ -26,6 +26,7 @@ export default {
   Render,
   Form,
   type: "Button",
+  label: "Button",
   description: "Button component that can be used as a call to action.",
 
   // validation: Yup.object()

--- a/src/Components/Email/Wrapper/index.js
+++ b/src/Components/Email/Wrapper/index.js
@@ -30,7 +30,7 @@ export default {
   Form,
   type: "Wrapper",
   description:
-    "The email wrapper component allows you to safley wrap content in standard email sizes.",
+    "The email wrapper component allows you to safely wrap content in standard email sizes.",
   defaultAttrs,
   generateContent: () => [
     {

--- a/src/Components/FiveCol/index.js
+++ b/src/Components/FiveCol/index.js
@@ -7,6 +7,7 @@ import Row from "../Row";
 export default {
   type: "FiveCol",
   description: "Five columns in a single row",
+  label: "Five Column Row",
   generateContent: () => [
     {
       id: generateUUID(),

--- a/src/Components/FourCol/index.js
+++ b/src/Components/FourCol/index.js
@@ -7,6 +7,7 @@ import Row from "../Row";
 export default {
   type: "FourCol",
   description: "Four columns in a single row",
+  label: "Four Column Row",
   generateContent: () => [
     {
       id: generateUUID(),

--- a/src/Components/HorizontalRule/index.js
+++ b/src/Components/HorizontalRule/index.js
@@ -16,6 +16,7 @@ export default {
   Render,
   Form,
   type: "HorizontalRule",
+  label: "Separator",
   description:
     "Horizontal Rule component to create a clear separation of content.",
   defaultAttrs,

--- a/src/Components/Image/index.js
+++ b/src/Components/Image/index.js
@@ -21,6 +21,7 @@ export default {
   Render,
   Form,
   type: "Image",
+  label: "Image",
   description:
     "Image component to display images or graphics in the page layout.",
   defaultAttrs,

--- a/src/Components/Row/index.js
+++ b/src/Components/Row/index.js
@@ -31,6 +31,7 @@ export default {
   Render,
   Form,
   type: "Row",
+  label: "Row", // cannot be called single column row because all multi-column rows become a Row after component selection
   description:
     "The row component allows you to group multiple components together. It can be used for vertically stacking components or positioning multiple components next to each other.",
 

--- a/src/Components/Text/index.js
+++ b/src/Components/Text/index.js
@@ -7,6 +7,7 @@ export default {
   Render,
   Form,
   type: "Text",
+  label: "Rich Text",
   description:
     "The Text component allows you to add custom text to the page layout.",
 

--- a/src/Components/ThreeCol/index.js
+++ b/src/Components/ThreeCol/index.js
@@ -6,6 +6,7 @@ import Row from "../Row";
 
 export default {
   type: "ThreeCol",
+  label: "Three Column Row",
   description: "Three columns in a single row",
   generateContent: () => [
     {

--- a/src/Components/TwoCol/index.js
+++ b/src/Components/TwoCol/index.js
@@ -6,6 +6,7 @@ import Row from "../Row";
 
 export default {
   type: "TwoCol",
+  label: "Two Column Row",
   description: "Two columns in a single row",
   generateContent: () => [
     {

--- a/src/Internals/SidebarForm.js
+++ b/src/Internals/SidebarForm.js
@@ -23,14 +23,17 @@ const SidebarForm = ({
         Editing {type}
       </Typography>
       <ul className={classes.breadcrumbs}>
-        {crumbs.map((crumb) => (
+        {crumbs.map((crumb, idx) => (
           <li key={`crumb-${crumb.id}`}>
             <a href="#" onClick={(e) => internals.showSidebar(e, crumb.id)}>
-              {crumb.type}
+              {crumb.label}
             </a>
+            <span className={classes.breadCrumbSeparator}>{" / "}</span>
           </li>
         ))}
-        {last && <li key={`crumb-${last.id}`}>{last.type}</li>}
+        {crumbs && !!crumbs.length && last && (
+          <li key={`crumb-${last.id}`}>{last.label}</li>
+        )}
       </ul>
       <div className={classes.grid}>{children}</div>
       <div className={classes.buttonGroup}>
@@ -62,18 +65,11 @@ const styles = (theme) => ({
     marginTop: "-10px",
     "& > li": {
       display: "inline",
-      marginRight: "10px",
-      position: "relative",
-      "&+li:before": {
-        content: '"/"',
-        position: "absolute",
-        bottom: "1px",
-        left: "-8px",
-        // width: "100%",
-        height: "1rem",
-        display: "block",
-      },
     },
+  },
+  breadCrumbSeparator: {
+    fontSize: "0.8rem",
+    color: "#111",
   },
 });
 

--- a/src/Internals/ToolboxModal/ComponentList.js
+++ b/src/Internals/ToolboxModal/ComponentList.js
@@ -51,7 +51,7 @@ const Sidebar = ({
           }
           key={component.type}
           className={classes.toolboxItem}
-          label={component.type}
+          label={component.label || component.type}
           handleComponentClick={handleComponentClick}
           type={component.type}
         />

--- a/src/Internals/ToolboxModal/ComponentPreview.js
+++ b/src/Internals/ToolboxModal/ComponentPreview.js
@@ -26,7 +26,7 @@ const ComponentPreview = ({ activeComponent, classes, internals }: $Props) => {
     return (
       <div className={classes.root}>
         <Typography type="heading6" gutterBottom>
-          {activeComponent.type} Preview
+          {activeComponent.label || activeComponent.type} Preview
         </Typography>
         <div className={classes.content}>
           {content

--- a/src/index.js
+++ b/src/index.js
@@ -348,7 +348,17 @@ class Editor extends Component<$Props, $State> {
     return reduce(
       contents,
       (paths, content, index) => {
-        const rPath = [...path, { id: content.id, type: content.type, index }];
+        const component = find(this.state.components, { type: content.type });
+        const rPath = [
+          ...path,
+          {
+            id: content.id,
+            label:
+              component && component.label ? component.label : content.type,
+            type: content.type,
+            index,
+          },
+        ];
         paths[content.id] = rPath;
         if (content.content.length) {
           return this.generatePathObject(content.content, rPath, paths);

--- a/types.js
+++ b/types.js
@@ -12,10 +12,11 @@ export type $ContentBlock = {|
 
 export type $Component = {
   Render?: any,
-  Preview?: any,
   Form?: any,
   generateContent?: ({ parent?: $ContentBlock }) => $ContentBlocks,
   type: string,
+  label?: string,
+  description?: string,
   defaultAttrs?: (Object) => Object,
 };
 export type $Components = $Component[];


### PR DESCRIPTION
## Component Labels (fallback to component type)
![screen shot 2019-01-07 at 4 46 08 pm](https://user-images.githubusercontent.com/246603/50800641-4ac3f600-129e-11e9-9dd5-45e657346492.png)

## Previously we showed a single non-clickable breadcrumb
![screen shot 2019-01-07 at 5 02 03 pm](https://user-images.githubusercontent.com/246603/50800642-4ac3f600-129e-11e9-90f2-6f4c89a379f0.png)

## Only show breadcrumbs if there is more than one 
![screen shot 2019-01-07 at 5 02 55 pm](https://user-images.githubusercontent.com/246603/50800643-4ac3f600-129e-11e9-9e80-d44e00414da1.png)

## Slightly modified breadcrumb styles

The `::after` CSS wasn't working well with the new labels so I modified it to rely less on CSS magic and more on rendered breadcrumb separators

![screen shot 2019-01-07 at 5 05 43 pm](https://user-images.githubusercontent.com/246603/50800693-865ec000-129e-11e9-87cf-8ce3b9077094.png)
