### PR TITLE
Extended Sidebar to Prevent Color Picker from Hiding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -628,13 +628,10 @@ export default withStyles((theme) => ({
     flexDirection: "column",
     flexShrink: "0",
     width: "100%",
-    height: "100%",
     overflowX: "hidden",
     overflowY: "auto",
-    background: theme.colors.gray050,
     padding: "8px",
     zIndex: Constants.zIndex.sidebar,
-    boxShadow: theme.globalBoxShadow,
     [theme.breakpoints(768)]: {
       width: "360px",
     },


### PR DESCRIPTION
Before:
<img width="391" alt="Screen Shot 2019-07-09 at 12 33 55 PM" src="https://user-images.githubusercontent.com/27472341/60917472-e2060800-a245-11e9-8f81-d37ab94d6b3d.png">

After:
<img width="413" alt="Screen Shot 2019-07-09 at 12 34 08 PM" src="https://user-images.githubusercontent.com/27472341/60917488-e6cabc00-a245-11e9-9573-0c2891a5f336.png">
